### PR TITLE
Use unordered_map when building folder tree

### DIFF
--- a/src/bsafolder.cpp
+++ b/src/bsafolder.cpp
@@ -138,76 +138,75 @@ std::string Folder::getFullPath() const
 
 void Folder::addFolderInt(Folder::Ptr folder)
 {
-  for (std::vector<Folder::Ptr>::iterator iter = m_SubFolders.begin();
-       iter != m_SubFolders.end(); ++iter) {
-    // for folder to be a subfolder of iter, the name of iter has to be the
-    // first path component of folders path and there has to be room left for a
-    // backslash and the name of folder itself
-    size_t nameLength = (*iter)->m_Name.length();
-    if ((folder->m_Name.length() > (*iter)->m_Name.length()) &&
-        (folder->m_Name.compare(0, (*iter)->m_Name.length(), (*iter)->m_Name) == 0) &&
-        ((folder->m_Name[nameLength] == '\\') || (folder->m_Name[nameLength] == '/'))) {
-      // remove the matched part of the path and recurse
-      folder->m_Name = folder->m_Name.substr((*iter)->m_Name.length() + 1);
-      (*iter)->addFolderInt(folder);
-      return;
-    }
+  std::filesystem::path path(folder->m_Name);
+  auto it              = path.begin();
+  std::string firstStr = it->string();
+  std::filesystem::path remaining;
+  for (++it; it != path.end(); ++it) {
+    remaining /= *it;
+  }
+
+  if (m_SubFoldersByName.contains(firstStr)) {
+    // remove the matched part of the path and recurse
+    folder->m_Name = remaining.string();
+    m_SubFoldersByName.at(firstStr)->addFolderInt(folder);
+    return;
   }
 
   // no subfolder matches, create one
-  std::string::size_type pos = folder->m_Name.find_first_of("\\/");
-  if (pos == std::string::npos) {
+  if (remaining.empty()) {
     // no more path components, add the new folder right here
     folder->m_Parent = this;
     m_SubFolders.push_back(folder);
+    m_SubFoldersByName[firstStr] = folder;
   } else {
     // add dummy folder for the next path component
     Folder::Ptr dummy(new Folder);
     dummy->m_Parent = this;
-    dummy->m_Name   = folder->m_Name.substr(0, pos);
-    folder->m_Name  = folder->m_Name.substr(pos + 1);
+    dummy->m_Name   = firstStr;
+    folder->m_Name  = remaining.string();
     dummy->addFolderInt(folder);
     m_SubFolders.push_back(dummy);
+    m_SubFoldersByName[firstStr] = dummy;
   }
 }
 
 Folder::Ptr Folder::addOrFindFolderInt(Folder* folder)
 {
-  for (std::vector<Folder::Ptr>::iterator iter = m_SubFolders.begin();
-       iter != m_SubFolders.end(); ++iter) {
-    // for folder to be a subfolder of iter, the name of iter has to be the
-    // first path component of folders path and there has to be room left for a
-    // backslash and the name of folder itself
-    size_t nameLength = (*iter)->m_Name.length();
-    if ((folder->m_Name.length() > (*iter)->m_Name.length()) &&
-        (folder->m_Name.compare(0, (*iter)->m_Name.length(), (*iter)->m_Name) == 0) &&
-        ((folder->m_Name[nameLength] == '\\') || (folder->m_Name[nameLength] == '/'))) {
+  std::filesystem::path path(folder->m_Name);
+  auto it              = path.begin();
+  std::string firstStr = it->string();
+  std::filesystem::path remaining;
+  for (++it; it != path.end(); ++it) {
+    remaining /= *it;
+  }
+
+  if (m_SubFoldersByName.contains(firstStr)) {
+    if (!remaining.empty()) {
       // remove the matched part of the path and recurse
-      folder->m_Name = folder->m_Name.substr((*iter)->m_Name.length() + 1);
-      return (*iter)->addOrFindFolderInt(folder);
+      folder->m_Name = remaining.string();
+      return m_SubFoldersByName.at(firstStr)->addOrFindFolderInt(folder);
     } else {
-      std::string::size_type pos = folder->m_Name.find_first_of("\\/");
-      if (pos == std::string::npos && (*iter)->m_Name.compare(folder->m_Name) == 0) {
-        return *iter;
-      }
+      return m_SubFoldersByName.at(firstStr);
     }
   }
 
   // no subfolder matches, create one
-  std::string::size_type pos = folder->m_Name.find_first_of("\\/");
-  if (pos == std::string::npos) {
+  if (remaining.empty()) {
     // no more path components, add the new folder right here
     folder->m_Parent = this;
     m_SubFolders.push_back(Folder::Ptr(folder));
+    m_SubFoldersByName[firstStr] = m_SubFolders.back();
     return m_SubFolders.back();
   } else {
     // add dummy folder for the next path component
     Folder::Ptr dummy(new Folder);
     dummy->m_Parent    = this;
-    dummy->m_Name      = folder->m_Name.substr(0, pos);
-    folder->m_Name     = folder->m_Name.substr(pos + 1);
+    dummy->m_Name      = firstStr;
+    folder->m_Name     = remaining.string();
     Folder::Ptr result = dummy->addOrFindFolderInt(folder);
     m_SubFolders.push_back(dummy);
+    m_SubFoldersByName[firstStr] = dummy;
     return result;
   }
 }

--- a/src/bsafolder.h
+++ b/src/bsafolder.h
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "errorcodes.h"
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace BSA
@@ -158,6 +159,7 @@ private:
   BSAULong m_FileCount;
   BSAHash m_Offset;
   std::vector<Folder::Ptr> m_SubFolders;
+  std::unordered_map<std::string, Folder::Ptr> m_SubFoldersByName;
   std::vector<File::Ptr> m_Files;
 
   mutable BSAULong m_OffsetWrite;


### PR DESCRIPTION
The goal of this change is to speed up reading the Starfield mesh archives. It should allow them to be viewed in a more reasonable time with the preview_bsa plugin. The problem stems from these archives having tens or hundreds of thousands of subdirectories under the geometries directory.